### PR TITLE
Save/Restore popup dimensions

### DIFF
--- a/views/_header.ejs
+++ b/views/_header.ejs
@@ -7,16 +7,3 @@
     <title><%= title %></title>
   </head>
   <body>
-    <script>
-      if (!! localStorage.width && !! localStorage.height) {
-        var w = parseInt(localStorage.getItem('width'), 10);
-        var h = parseInt(localStorage.getItem('height'), 10);
-        if (! isNaN(w) && w > 100 && ! isNaN(h) && h > 100) {
-          window.resizeTo(w, h);
-          if (localStorage.removeItem) {
-            localStorage.removeItem('width');
-            localStorage.removeItem('height');
-          }
-        }
-      }
-    </script>

--- a/views/_restore.ejs
+++ b/views/_restore.ejs
@@ -1,0 +1,13 @@
+<script>
+  if (!! localStorage.width && !! localStorage.height) {
+    var w = parseInt(localStorage.getItem('width'), 10);
+    var h = parseInt(localStorage.getItem('height'), 10);
+    if (! isNaN(w) && w > 100 && ! isNaN(h) && h > 100) {
+      window.resizeTo(w, h);
+      if (localStorage.removeItem) {
+        localStorage.removeItem('width');
+        localStorage.removeItem('height');
+      }
+    }
+  }
+</script>

--- a/views/authenticate.ejs
+++ b/views/authenticate.ejs
@@ -2,9 +2,11 @@
 <h1><%= title %></h1>
 <script src="http://127.0.0.1:10002/authentication_api.js"></script>
 <script>
+  // Store window dimensions, to be restored upon returning from Google OpenID
   localStorage.height = window.outerHeight || document.documentElement.offsetHeight;
   localStorage.width = window.outerWidth || document.documentElement.offsetWidth;
 
+  // Get the claimed email address and hand it off to the backend
   navigator.id.beginAuthentication(function (email) {
     var escapedEmail = encodeURIComponent(email);
     window.location = '/authenticate/forward?email=' + escapedEmail;

--- a/views/authenticate_finish.ejs
+++ b/views/authenticate_finish.ejs
@@ -1,4 +1,5 @@
 <% include _header %>
+<% include _restore %>
 <h1><%= title %></h1>
 <script src="http://127.0.0.1:10002/authentication_api.js"></script>
 <script>

--- a/views/error.ejs
+++ b/views/error.ejs
@@ -1,4 +1,5 @@
 <% include _header %>
+<% include _restore %>
 <h1><%= title %></h1>
 <p><%= gettext("Something went wrong. Please try again later.") %></p>
 <p><a href="http://127.0.0.1:10002/sign_in#AUTH_RETURN_CANCEL">Cancel</a></p>

--- a/views/error_mismatch.ejs
+++ b/views/error_mismatch.ejs
@@ -1,4 +1,5 @@
 <% include _header %>
+<% include _restore %>
 <h1><%= title %></h1>
 <p><%- format(gettext("It looks like you were trying to sign in as %(claimed)s but were actually signed into Google as %(proven)s."),
        { claimed: '<b>' + escape(claimed) + '</b>', proven: '<b>' + proven + '</b>' }) %></p>


### PR DESCRIPTION
Fixes #6 

I'm wondering if we should do this at all, since the Google popup only resizes to ensure a minimum window height, and it only does this on the OpenID permissions page. Thus, you only need this the very first time an address goes through the Google bridge, and never again.

I'll defer to UX before merging.
