### PR TITLE
Clean up logging

### DIFF
--- a/bin/sideshow.js
+++ b/bin/sideshow.js
@@ -91,9 +91,14 @@ app.use(express.csrf());
 express.logger.token('path', function(req) {
   return req.path;
 });
+express.logger.token('safe-referrer', function(req) {
+  var referrer = req.headers.referer || req.headers.referrer || '';
+  var queryIdx = referrer.indexOf('?');
+  return (queryIdx < 0) ? referrer : referrer.slice(0, queryIdx);
+});
 app.use(express.logger({
   format: ':remote-addr - - ":method :path HTTP/:http-version" :status ' +
-          ':response-time :res[content-length] ":referrer" ":user-agent"',
+          ':response-time :res[content-length] ":safe-referrer" ":user-agent"',
   stream: {
     write: function(x) {
       logger.info(String(x).trim());

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const winston = require('winston');
-const express = require('express');
 
 const config = require('./config');
 


### PR DESCRIPTION
1. `lib/logging` doesn't need Express
2. `:referrer` can leak user email addresses into our logs
