### PR TITLE
Silence application logging during tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Visit http://127.0.0.1:10001/ and try signing in with your Gmail account!
 Testing
 -------
 
-1. `LOG_PATH=/dev/null npm test`
+1. `npm test`
 
 You're done!
 

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -9,18 +9,22 @@ const config = require('./config');
 var transports = [];
 var logPath = config.get('logPath');
 
-if (logPath && logPath !== '-') {
+
+
+if (!logPath || logPath === '-') {
+  // Default to console logging
+  transports.push(new (winston.transports.Console)({
+    colorize: true,
+    handleException: true,
+    level: 'debug'
+  }));
+} else if (logPath && logPath !== '/dev/null') {
+  // Don't log to /dev/null, Windows doesn't have it.
   transports.push(new (winston.transports.File)({
     timestamp: function() { return new Date().toISOString(); },
     filename: logPath,
     colorize: true,
     handleException: true
-  }));
-} else {
-  transports.push(new (winston.transports.Console)({
-    colorize: true,
-    handleException: true,
-    level: 'debug'
   }));
 }
 

--- a/test/server.js
+++ b/test/server.js
@@ -2,6 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// Silence app logging by default. Must come before require('../bin/sideshow');
+const config = require('../lib/config');
+if (config.get('logPath') === config.default('logPath') &&
+    !process.env.LOG_PATH) {
+  config.set('logPath', '/dev/null');
+}
+
 const assert = require('assert');
 
 const jwcrypto = require('jwcrypto');
@@ -9,7 +16,6 @@ const request = require('request');
 const openid = require('openid');
 
 const app = require('../bin/sideshow');
-const config = require('../lib/config');
 const mockid = require('./lib/mockid');
 const mookie = require('./lib/cookie');
 


### PR DESCRIPTION
The application logging was bugging me during `npm test`, especially when we test error conditions. ;)

This silences logging by default, but turns it back on if you explicitly specify a log path or set the `LOG_PATH` environment variable.
