### PR TITLE
make personaUrl config format stricter

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -42,7 +42,11 @@ const conf = convict({
   personaUrl : {
     doc: 'The full URL of the Persona service. Used to find JavaScript shims.',
     env: 'PERSONA_URL',
-    format: 'url',
+    format: function(x) {
+      if (!x.match(/^https?:\/\/[^\/]{1,}$/)) {
+        throw new Error('not valid scheme+hostname');
+      }
+    },
     default: 'http://127.0.0.1:10002'
   },
   secret: {


### PR DESCRIPTION
fixes #72 

Reasoning: `https://login.anosrep.org/` was accidentally used in staging, and the server started up with no problems. However, it breaks CSP (the trailing slash), and makes our requests for auth and provisioning apis to use 2 slashes.
