### PR TITLE
Remove `Connection: close` header from XHR

### DIFF
--- a/static/js/provision.js
+++ b/static/js/provision.js
@@ -40,7 +40,6 @@
       }
 
       req.setRequestHeader('Accept', 'application/json;text/plain');
-      req.setRequestHeader('Connection', 'close');
 
       req.send(data || null);
     }


### PR DESCRIPTION
The browser automatically sets this header for you. Setting it only
throws a security error, muddying up the console.

Fixes part of mozilla/browserid issue #3700
