### PR TITLE
Fix i18n-abide version to include dash

### DIFF
--- a/lockdown.json
+++ b/lockdown.json
@@ -209,7 +209,7 @@
     "0.9.11": "9e882714572315e6790a5d0a7955efff1f19e653"
   },
   "i18n-abide": {
-    "0.0.8beta9": "c6659ccdd3f030061572177e1d1a93da9e2affbd"
+    "0.0.8-beta9": "c6659ccdd3f030061572177e1d1a93da9e2affbd"
   },
   "inherits": {
     "1.0.0": "38e1975285bf1f7ba9c84da102bb12771322ac48"


### PR DESCRIPTION
Trying to initially `npm install` dependencies and I get the following error during install:

```
LOCKDOWN ERRORS:
    package version i18n-abide@0.0.8-beta9 not in lockdown.json!
```

The following change seemed to fix the issue.

Tried this on both `node v0.10.15 (npm v1.3.5)` and  `node v0.8.24 (npm v1.2.24)` and it seemed to fix.
