### PR TITLE
Add makefile to match persona and persona-yahoo-bridge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+clean:
+	rm -rf node_modules rpmbuild
+
+npm:
+	npm install
+
+rpm: npm
+	scripts/rpmbuild.sh HEAD
+
+test: npm
+	npm test
+
+jenkins_build: clean npm test rpm


### PR DESCRIPTION
not quite identical to the one from [mozilla/persona](https://github.com/mozilla/persona), because <code>scripts/rpmbuild.sh</code> requires a git reference as <code>$1</code>, so I used <code>HEAD</code>, to match funcationality.
